### PR TITLE
Fix blob default

### DIFF
--- a/mysql_to_sqlite3/__version__.py
+++ b/mysql_to_sqlite3/__version__.py
@@ -2,7 +2,7 @@
 __title__ = "mysql-to-sqlite3"
 __description__ = "A simple Python tool to transfer data from MySQL to SQLite 3"
 __url__ = "https://github.com/techouse/mysql-to-sqlite3"
-__version__ = "1.4.14"
+__version__ = "1.4.15"
 __author__ = "Klemen Tusar"
 __author_email__ = "techouse@gmail.com"
 __license__ = "MIT"

--- a/mysql_to_sqlite3/transporter.py
+++ b/mysql_to_sqlite3/transporter.py
@@ -278,7 +278,7 @@ class MySQLtoSQLite:
                 "CURRENT_TIMESTAMP",
             }:
                 return "DEFAULT {}".format(column_default.upper())
-        return "DEFAULT '{}'".format(column_default)
+        return "DEFAULT {}".format(column_default.strip('b'))
 
     @classmethod
     def _data_type_collation_sequence(

--- a/mysql_to_sqlite3/transporter.py
+++ b/mysql_to_sqlite3/transporter.py
@@ -305,7 +305,8 @@ class MySQLtoSQLite:
             return False
 
     def _build_create_table_sql(self, table_name):
-        sql = 'CREATE TABLE IF NOT EXISTS "{}" ('.format(table_name)
+        # sql = 'CREATE TABLE IF NOT EXISTS "{}" ('.format(table_name)
+        sql = 'CREATE TABLE IF NOT EXISTS "{}"\n\t--{}\n('.format(table_name, self._mysql_database)
         primary = ""
         indices = ""
 


### PR DESCRIPTION
- Fixed issue where the blobl MySQL BIT would fail due to the default value being b'1' or b'0' instead of '1' or '0'. Shouldn't break it, but it seems to be in the sqlite3 library itself where the issue is.
- Added in the source database name into a comment of the source SQL script, which is stored in the sqlite_master table. This is useful when you have tables from multiple databases stored together and is an easy way to store and retrieve the names.